### PR TITLE
Feature/#60 deploy as nuget packages

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ pool:
 # install dotnet sdk 3.x
 steps:
 - task: UseDotNet@2
-  displayName: '//=> install dotnet sdk 3.x'
+  displayName: '//=> dotnet install sdk 3.x'
   inputs:
     packageType: sdk
     version: 3.x
@@ -45,5 +45,18 @@ steps:
   displayName: '//=> dotnet pack'
   inputs:
      command: pack
-     projects: '**/*.csproj'
-     arguments: '--include-symbols --verbosity normal --configuration Release --output https://pkgs.dev.azure.com/antonyoung/Validator/_packaging/antonyoung-nuget-packages/nuget/v3/index.json'
+     versioningScheme: byPrereleaseNumbe
+     packagesToPack: '**/*.csproj'
+     configuration: $(BuildConfiguration)
+     packDestination: $(Build.ArtifactStagingDirectory)
+     #arguments: '--include-symbols --verbosity normal --configuration Release --output https://pkgs.dev.azure.com/antonyoung/Validator/_packaging/antonyoung-nuget-packages/nuget/v3/index.json'
+
+steps:
+- task: NuGetAuthenticate@0
+  displayName: '//=> NuGet Authenticate'
+- task: NuGetCommand@2
+  displayName: '//=> dotnet push'
+  inputs:
+    command: push
+    publishVstsFeed: 'Validator/antonyoung-nuget-packages'
+    allowPackageConflicts: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ pool:
 # install dotnet sdk 3.x
 steps:
 - task: UseDotNet@2
-  displayName: '// => install dotnet sdk 3.x'
+  displayName: '//=> install dotnet sdk 3.x'
   inputs:
     packageType: sdk
     version: 3.x
@@ -24,18 +24,26 @@ steps:
 # restore nuget packages
 # - script: dotnet restore
 
-# build all projects as Release
+# dotenet build all projects as Release
 - task: DotNetCoreCLI@2
-  displayName: '// => dotnet build'
+  displayName: '//=> dotnet build'
   inputs:
     command: build
     projects: '**/*.csproj'
     arguments: '--configuration Release'
 
-# run all tests and collect code coverage
+# dotenet test all tests and collect code coverage
 - task: DotNetCoreCLI@2
-  displayName: '// => dotnet test'
+  displayName: '//=> dotnet test'
   inputs:
     command: test
     projects: '**/*Tests/*.csproj'
     arguments: '--configuration $(BuildConfiguration) --collect:"XPlat Code Coverage"'
+
+# dotenet pack all projects as Release
+task: DotNetCoreCLI@2
+displayName: '//=> dotnet pack'
+inputs:
+    command: pack
+    projects: '**/*.csproj'
+    arguments: '--include-symbols --verbosity normal --configuration Release --output https://pkgs.dev.azure.com/antonyoung/Validator/_packaging/antonyoung-nuget-packages/nuget/v3/index.json'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,9 +51,7 @@ steps:
      packDestination: $(Build.ArtifactStagingDirectory)
      #arguments: '--include-symbols --verbosity normal --configuration Release --output https://pkgs.dev.azure.com/antonyoung/Validator/_packaging/antonyoung-nuget-packages/nuget/v3/index.json'
 
-steps:
-- task: NuGetAuthenticate@0
-  displayName: '//=> NuGet Authenticate'
+# dotenet push nuget-packages to project/feed
 - task: NuGetCommand@2
   displayName: '//=> dotnet push'
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,9 +41,9 @@ steps:
     arguments: '--configuration $(BuildConfiguration) --collect:"XPlat Code Coverage"'
 
 # dotenet pack all projects as Release
-task: DotNetCoreCLI@2
-displayName: '//=> dotnet pack'
-inputs:
-    command: pack
-    projects: '**/*.csproj'
-    arguments: '--include-symbols --verbosity normal --configuration Release --output https://pkgs.dev.azure.com/antonyoung/Validator/_packaging/antonyoung-nuget-packages/nuget/v3/index.json'
+- task: DotNetCoreCLI@2
+  displayName: '//=> dotnet pack'
+  inputs:
+     command: pack
+     projects: '**/*.csproj'
+     arguments: '--include-symbols --verbosity normal --configuration Release --output https://pkgs.dev.azure.com/antonyoung/Validator/_packaging/antonyoung-nuget-packages/nuget/v3/index.json'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,6 @@ steps:
      packagesToPack: '**/*.csproj'
      configuration: $(BuildConfiguration)
      packDestination: $(Build.ArtifactStagingDirectory)
-     #arguments: '--include-symbols --verbosity normal --configuration Release --output https://pkgs.dev.azure.com/antonyoung/Validator/_packaging/antonyoung-nuget-packages/nuget/v3/index.json'
 
 # dotenet push nuget-packages to project/feed
 - task: NuGetCommand@2

--- a/src/AntonYoung.Validators.Abstractions/Properties/version.props
+++ b/src/AntonYoung.Validators.Abstractions/Properties/version.props
@@ -8,7 +8,7 @@
     <VersionPrefix>0.0.1</VersionPrefix>
     <VersionSuffix>F60</VersionSuffix>
     <Product>AntonYoung.Validators.Abstractions</Product>
-    <PackageTags>Validators shared dependency</PackageTags>
+    <PackageTags>Shared dependency used by Anton.Young.Validators</PackageTags>
     <Description>Shared dependency on Iban, Postalcode validators</Description>
     <Copyright>Copyright © 2021 Anton Young, Amsterdam</Copyright>
     <SignAssembly>True</SignAssembly>

--- a/src/AntonYoung.Validators.Abstractions/Properties/version.props
+++ b/src/AntonYoung.Validators.Abstractions/Properties/version.props
@@ -6,7 +6,7 @@
     <Authors>Anton Young</Authors>
     <Company/>
     <VersionPrefix>0.0.1</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
+    <VersionSuffix>F60</VersionSuffix>
     <Product>AntonYoung.Validators.Abstractions</Product>
     <PackageTags>Validators shared dependency</PackageTags>
     <Description>Shared dependency on Iban, Postalcode validators</Description>

--- a/src/AntonYoung.Validators.Iban/Properties/version.props
+++ b/src/AntonYoung.Validators.Iban/Properties/version.props
@@ -8,7 +8,7 @@
     <VersionPrefix>0.0.1</VersionPrefix>
     <VersionSuffix>F60</VersionSuffix>
     <Product>AntonYoung.Validators.Iban</Product>
-    <PackageTags>European iban Validator</PackageTags>
+    <PackageTags>European IBAN Validator</PackageTags>
     <Description>Validator for European International Bank Account Number (IBAN)</Description>
     <Copyright>Copyright © 2021 Anton Young, Amsterdam</Copyright>
     <SignAssembly>True</SignAssembly>

--- a/src/AntonYoung.Validators.Iban/Properties/version.props
+++ b/src/AntonYoung.Validators.Iban/Properties/version.props
@@ -6,7 +6,7 @@
     <Authors>Anton Young</Authors>
     <Company/>
     <VersionPrefix>0.0.1</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
+    <VersionSuffix>F60</VersionSuffix>
     <Product>AntonYoung.Validators.Iban</Product>
     <PackageTags>European iban Validator</PackageTags>
     <Description>Validator for European International Bank Account Number (IBAN)</Description>

--- a/src/AntonYoung.Validators.Postalcode/Properties/version.props
+++ b/src/AntonYoung.Validators.Postalcode/Properties/version.props
@@ -8,8 +8,8 @@
     <VersionPrefix>0.0.1</VersionPrefix>
     <VersionSuffix>F60</VersionSuffix>
     <Product>AntonYoung.Validators.Postalcode</Product>
-    <PackageTags>Validator European postalcodes</PackageTags>
-    <Description>Validator for Euroepan Postalcodes</Description>
+    <PackageTags>European postalcodes Validator</PackageTags>
+    <Description>Validator for European Postalcodes</Description>
     <Copyright>Copyright © 2021 Anton Young, Amsterdam</Copyright>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\AntonYoung.Validators.snk</AssemblyOriginatorKeyFile>

--- a/src/AntonYoung.Validators.Postalcode/Properties/version.props
+++ b/src/AntonYoung.Validators.Postalcode/Properties/version.props
@@ -6,7 +6,7 @@
     <Authors>Anton Young</Authors>
     <Company/>
     <VersionPrefix>0.0.1</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
+    <VersionSuffix>F60</VersionSuffix>
     <Product>AntonYoung.Validators.Postalcode</Product>
     <PackageTags>Validator European postalcodes</PackageTags>
     <Description>Validator for Euroepan Postalcodes</Description>


### PR DESCRIPTION
alright, nuget-packages are now published to my private nuget-packages/feed in Azure DevOps via yaml pipleline.
still some issues, incase version is equals to previous version ( nuget-package(s) exist and pipeline will fail ) 
at least we can think about adding nuget-package version badge(s) and the Azure CI / CD pipeline is improving.

Note:
* for now only published into private nuget-packages/feed
* todo: versioning ( would be nice to add versionsuffix as preview version automatically. )
* todo: add nuget-package version badge
* todo: publish as organization in Azure DevOps ( eventually in NuGet )